### PR TITLE
fix floating point

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(
         "Multiroute flows"   => "multiroute.md",
         "Min-cost flows"     => "mincost.md",
         "Min-cut"            => "mincut.md",
+        "Internals"          => "internals.md",
     ]
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
- # GraphsFlows.jl: flow algorithms for Graphs.jl
+# GraphsFlows.jl: flow algorithms for Graphs.jl
 
 ```@meta
 CurrentModule = GraphsFlows
@@ -6,12 +6,6 @@ DocTestSetup = quote
     using GraphsFlows
     import Graphs
 end
-```
-
-```@autodocs
-Modules = [GraphsFlows]
-Pages = ["GraphsFlows.jl"]
-Order = [:function, :type]
 ```
 
 This is the documentation page for `GraphsFlows`. In all pages, we assume

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -4,4 +4,5 @@
 GraphsFlows.DefaultCapacity
 GraphsFlows.AbstractFlowAlgorithm
 GraphsFlows.residual
+GraphsFlows.is_zero
 ```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,7 @@
+# Internals
+
+```@docs
+GraphsFlows.DefaultCapacity
+GraphsFlows.AbstractFlowAlgorithm
+GraphsFlows.residual
+```

--- a/docs/src/maxflow.md
+++ b/docs/src/maxflow.md
@@ -1,5 +1,13 @@
 ## Max flow algorithms
 
+```@docs
+maximum_flow
+EdmondsKarpAlgorithm
+DinicAlgorithm
+PushRelabelAlgorithm
+BoykovKolmogorovAlgorithm
+```
+
 ```@autodocs
 Modules = [GraphsFlows]
 Pages = ["maxflow.jl", "boykov_kolmogorov.jl", "push_relabel.jl", "dinic.jl", "edmonds_karp.jl"]

--- a/src/dinic.jl
+++ b/src/dinic.jl
@@ -21,7 +21,7 @@ function dinic_impl end
 
     while true
         augment = blocking_flow!(residual_graph, source, target, capacity_matrix, flow_matrix, P)
-        augment == 0 && break
+        is_zero(augment) && break
         flow += augment
     end
     return flow, flow_matrix
@@ -80,7 +80,7 @@ function blocking_flow! end
             end
         end
 
-        flow == 0 && continue                      # Flow cannot be augmented along path
+        is_zero(flow) && continue                      # Flow cannot be augmented along path
 
         v = target
         u = bv

--- a/src/dinic.jl
+++ b/src/dinic.jl
@@ -11,8 +11,10 @@ function dinic_impl end
         residual_graph::::Graphs.IsDirected,               # the input graph
         source::Integer,                       # the source vertex
         target::Integer,                       # the target vertex
-        capacity_matrix::AbstractMatrix{T}    # edge flow capacities
+        capacity_matrix::AbstractMatrix{T};    # edge flow capacities
+        tolerance::T = (T <: AbstractFloat) ? sqrt(eps(T)) : zero(T)
     ) where {T}
+
     n = Graphs.nv(residual_graph)                     # number of vertexes
     flow_matrix = zeros(T, n, n)           # initialize flow matrix
     P = zeros(Int, n)                      # Sharable parent vector
@@ -20,8 +22,8 @@ function dinic_impl end
     flow = 0
 
     while true
-        augment = blocking_flow!(residual_graph, source, target, capacity_matrix, flow_matrix, P)
-        is_zero(augment) && break
+        augment = blocking_flow!(residual_graph, source, target, capacity_matrix, flow_matrix, P; tolerance = tolerance)
+        is_zero(augment; atol = tolerance) && break
         flow += augment
     end
     return flow, flow_matrix
@@ -42,7 +44,8 @@ function blocking_flow! end
         target::Integer,                     # the target vertex
         capacity_matrix::AbstractMatrix{T},  # edge flow capacities
         flow_matrix::AbstractMatrix,         # the current flow matrix
-        P::AbstractVector{Int}               # Parent vector to store Level Graph
+        P::AbstractVector{Int};               # Parent vector to store Level Graph
+        tolerance = (T <: AbstractFloat) ? sqrt(eps(T)) : zero(T)
     ) where {T}
     n = Graphs.nv(residual_graph)                # number of vertexes
     fill!(P, -1)
@@ -80,7 +83,7 @@ function blocking_flow! end
             end
         end
 
-        is_zero(flow) && continue                      # Flow cannot be augmented along path
+        is_zero(flow; atol = tolerance) && continue  # Flow cannot be augmented along path
 
         v = target
         u = bv
@@ -108,11 +111,13 @@ blocking_flow(
     source::Integer,                   # the source vertex
     target::Integer,                   # the target vertex
     capacity_matrix::AbstractMatrix,   # edge flow capacities
-    flow_matrix::AbstractMatrix,       # the current flow matrix
-    ) = blocking_flow!(
+    flow_matrix::AbstractMatrix{T};       # the current flow matrix
+    tolerance = (T <: AbstractFloat) ? sqrt(eps(T)) : zero(T)
+    ) where {T}= blocking_flow!(
             residual_graph,
             source,
             target,
             capacity_matrix,
             flow_matrix,
-            zeros(Int, Graphs.nv(residual_graph)))
+            zeros(Int, Graphs.nv(residual_graph)); 
+            tolerance = tolerance)

--- a/src/maximum_flow.jl
+++ b/src/maximum_flow.jl
@@ -180,8 +180,9 @@ function maximum_flow(
 end
 
 """
-is_zero(value)
+    is_zero(value; tolerance)
+
 Test if the value is equal to zero. It handles floating point errors.
 """
-is_zero(value::T; atol = sqrt(eps(T))) where {T<:AbstractFloat} = isapprox(value, 0, atol = atol)
-is_zero(value; atol) = (value == 0)
+is_zero(value::T; atol = sqrt(eps(T))) where {T<:AbstractFloat} = isapprox(value, zero(T), atol = atol)
+is_zero(value; atol) = iszero(value)

--- a/src/maximum_flow.jl
+++ b/src/maximum_flow.jl
@@ -183,5 +183,5 @@ end
 is_zero(value)
 Test if the value is equal to zero. It handles floating point errors.
 """
-is_zero(value::T) where {T<:AbstractFloat} = isapprox(value, 0, atol = sqrt(eps(T)))
-is_zero(value) = (value == 0)
+is_zero(value::T; atol = sqrt(eps(T))) where {T<:AbstractFloat} = isapprox(value, 0, atol = atol)
+is_zero(value; atol) = (value == 0)

--- a/src/maximum_flow.jl
+++ b/src/maximum_flow.jl
@@ -178,3 +178,10 @@ function maximum_flow(
     end
     return maximum_flow(flow_graph, source, target, capacity_matrix, algorithm)
 end
+
+"""
+is_zero(value)
+Test if the value is equal to zero. It handles floating point errors.
+"""
+is_zero(value::T) where {T<:AbstractFloat} = isapprox(value, 0, atol = sqrt(eps(T)))
+is_zero(value) = (value == 0)

--- a/src/push_relabel.jl
+++ b/src/push_relabel.jl
@@ -189,11 +189,11 @@ function discharge! end
         Q::AbstractVector                   # FIFO queue
     )
     for to in Graphs.outneighbors(residual_graph, v)
-        excess[v] == 0 && break
+        is_zero(excess[v]) && break
         push_flow!(residual_graph, v, to, capacity_matrix, flow_matrix, excess, height, active, Q)
     end
 
-    if excess[v] > 0
+    if ! is_zero(excess[v])
         if count[height[v] + 1] == 1
             gap!(residual_graph, height[v], excess, height, active, count, Q)
         else

--- a/src/push_relabel.jl
+++ b/src/push_relabel.jl
@@ -12,7 +12,8 @@ function push_relabel end
         residual_graph::::Graphs.IsDirected,       # the input graph
         source::Integer,                       # the source vertex
         target::Integer,                       # the target vertex
-        capacity_matrix::AbstractMatrix{T}     # edge flow capacities
+        capacity_matrix::AbstractMatrix{T};     # edge flow capacities
+        tolerance::T = (T <: AbstractFloat) ? sqrt(eps(T)) : zero(T)
     ) where {T}
 
     n = Graphs.nv(residual_graph)
@@ -43,7 +44,7 @@ function push_relabel end
     while length(Q) > 0
         v = pop!(Q)
         active[v] = false
-        discharge!(residual_graph, v, capacity_matrix, flow_matrix, excess, height, active, count, Q)
+        discharge!(residual_graph, v, capacity_matrix, flow_matrix, excess, height, active, count, Q; tolerance = tolerance)
     end
 
     return sum([flow_matrix[v, target] for v in Graphs.inneighbors(residual_graph, target)]), flow_matrix
@@ -180,20 +181,21 @@ function discharge! end
 @traitfn function discharge!(
         residual_graph::::Graphs.IsDirected,    # the input graph
         v::Integer,                         # vertex to be discharged
-        capacity_matrix::AbstractMatrix,
+        capacity_matrix::AbstractMatrix{T},
         flow_matrix::AbstractMatrix,
         excess::AbstractVector,
         height::AbstractVector{Int},
         active::AbstractVector{Bool},
         count::AbstractVector{Int},
-        Q::AbstractVector                   # FIFO queue
-    )
+        Q::AbstractVector;                   # FIFO queue
+        tolerance = (T <: AbstractFloat) ? sqrt(eps(T)) : zero(T)
+    ) where {T}
     for to in Graphs.outneighbors(residual_graph, v)
-        is_zero(excess[v]) && break
+        is_zero(excess[v]; atol = tolerance) && break
         push_flow!(residual_graph, v, to, capacity_matrix, flow_matrix, excess, height, active, Q)
     end
 
-    if ! is_zero(excess[v])
+    if ! is_zero(excess[v]; atol = tolerance)
         if count[height[v] + 1] == 1
             gap!(residual_graph, height[v], excess, height, active, count, Q)
         else

--- a/test/push_relabel.jl
+++ b/test/push_relabel.jl
@@ -91,4 +91,24 @@
             0 0 0 0 1 0]
     g448 = Graphs.DiGraph(M448)
     @test maximum_flow(g448, 1, 2, M448, algorithm=PushRelabelAlgorithm())[1] == 1
+
+    # Non regression test for floating point error (issue #28 in LightGraphsFlows.jl)
+    M28 = [0 0 1 1 1 0 0 0
+           0 0 0 0 0 0 0 0
+           0 0 0 0 0 1 1 1
+           0 0 0 0 0 1 1 1
+           0 0 0 0 0 1 1 1
+           0 1 0 0 0 0 0 0
+           0 1 0 0 0 0 0 0
+           0 1 0 0 0 0 0 0]
+    g28 = Graphs.DiGraph(M28)
+    C28 = [0. 0. 0.1 0.1 0.1 0. 0. 0.
+        0. 0. 0. 0. 0. 0. 0. 0.
+        0. 0. 0. 0. 0. 1. 1. 1.
+        0. 0. 0. 0. 0. 1. 1. 1.
+        0. 0. 0. 0. 0. 1. 1. 1.
+        0. 0. 0. 0. 0. 0. 0. 0.
+        0. 0. 0. 0. 0. 0. 0. 0.
+        0. 0. 0. 0. 0. 0. 0. 0.]
+    @test maximum_flow(g28, 1, 2, C28, algorithm=PushRelabelAlgorithm())[1] == 0
 end


### PR DESCRIPTION
This is a repost of my [PR](https://github.com/JuliaGraphs/LightGraphsFlows.jl/pull/31) on LightGraphsFlows.jl. 
Closes [#28](https://github.com/JuliaGraphs/LightGraphsFlows.jl/issues/28).
`is_zero` is necessary because when comparing against zero, this is equivalent to strict equality (only absolute difference is tolerated). `eps` is not defined for Integers so we need to separate `AbstractFloat` from `Integer`.
From last PR, I re-coded the `is_zero` function to take advantage of multiple dispatch, and added a non regression test.

As we only add errors, should I use `nv(g)*eps(T)` instead of `sqrt(eps(T))`?
